### PR TITLE
Support for AOAI's o1-preview and o1-mini model.

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
 					"default": true,
 					"description": "Enables extension to save checkpoints of workspace throughout the task."
 				},
-				"cline.modelSettings.o3Mini.reasoningEffort": {
+				"cline.modelSettings.o-series.reasoningEffort": {
 					"type": "string",
 					"enum": [
 						"low",

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -52,7 +52,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 					messages: [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 					stream: true,
 					stream_options: { include_usage: true },
-					reasoning_effort: (this.options.o3MiniReasoningEffort as ChatCompletionReasoningEffort) || "medium",
+					reasoning_effort: (this.options.oSeriesReasoningEffortLevel as ChatCompletionReasoningEffort) || "medium",
 				})
 				for await (const chunk of stream) {
 					const delta = chunk.choices[0]?.delta

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -50,7 +50,7 @@ export class OpenAiHandler implements ApiHandler {
 			stream: true,
 			stream_options: { include_usage: true },
 			reasoning_effort: this.options.isReasoningModel
-				? (this.options.o3MiniReasoningEffort as ChatCompletionReasoningEffort) || "medium"
+				? (this.options.oSeriesReasoningEffortLevel as ChatCompletionReasoningEffort) || "medium"
 				: undefined,
 		})
 		for await (const chunk of stream) {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -130,7 +130,7 @@ export class OpenRouterHandler implements ApiHandler {
 			stream: true,
 			transforms: shouldApplyMiddleOutTransform ? ["middle-out"] : undefined,
 			include_reasoning: true,
-			...(model.id === "openai/o3-mini" ? { reasoning_effort: this.options.o3MiniReasoningEffort || "medium" } : {}),
+			...(model.id === "openai/o3-mini" ? { reasoning_effort: this.options.oSeriesReasoningEffortLevel || "medium" } : {}),
 		})
 
 		let genId: string | undefined

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1486,8 +1486,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			}
 		}
 
-		const o3MiniReasoningEffort = vscode.workspace
-			.getConfiguration("cline.modelSettings.o3Mini")
+		const oSeriesReasoningEffort = vscode.workspace
+			.getConfiguration("cline.modelSettings.o-series")
 			.get("reasoningEffort", "medium")
 
 		return {
@@ -1528,7 +1528,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				openRouterModelId,
 				openRouterModelInfo,
 				vsCodeLmModelSelector,
-				o3MiniReasoningEffort,
+				oSeriesReasoningEffort,
 				liteLlmBaseUrl,
 				liteLlmModelId,
 			},

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -53,7 +53,7 @@ export interface ApiHandlerOptions {
 	azureApiVersion?: string
 	isReasoningModel?: boolean
 	vsCodeLmModelSelector?: any
-	o3MiniReasoningEffort?: string
+	oSeriesReasoningEffortLevel?: string
 	qwenApiLine?: string
 }
 


### PR DESCRIPTION
### Description

Support for AOAI's o1-preview and o1-mini model.

### Test Procedure

none

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

none

### Additional Notes

I check the following references:
1. [https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning?wt.mc_id=DT-MVP-5001645)
2. [https://help.openai.com/en/articles/10362446-api-access-to-o1-and-o3-mini](https://help.openai.com/en/articles/10362446-api-access-to-o1-and-o3-mini)
3. [https://platform.openai.com/docs/guides/reasoning#advice-on-prompting](https://platform.openai.com/docs/guides/reasoning#advice-on-prompting)
4. [https://github.com/openai/openai-dotnet/issues/332#issuecomment-2644464067](https://github.com/openai/openai-dotnet/issues/332#issuecomment-2644464067)

I'm not sure it will run well done in VSCode Extension.
